### PR TITLE
Improve compatibility with Python <3.10

### DIFF
--- a/wtforms_bootstrap5/registry.py
+++ b/wtforms_bootstrap5/registry.py
@@ -10,7 +10,7 @@ from wtforms import Form
 from .helpers import traverse_base_classes
 
 # Union type of form element
-FormElement = Field | Form
+FormElement = typing.Union[Field, Form]
 # Type for form element renderer
 FormElementRenderer = typing.Callable[["RenderContext", FormElement], Markup]
 


### PR DESCRIPTION
Haven't run full compatibility tests, but this was a definite 3.10 only syntax, and 3.8/3.9 are still used wide enough that it's worth such a small change.