### PR TITLE
Remove dict union operator for 3.8 compatibility

### DIFF
--- a/wtforms_bootstrap5/context.py
+++ b/wtforms_bootstrap5/context.py
@@ -116,7 +116,7 @@ class RendererContext:
 
     def form(self, **kwargs) -> RendererContext:
         old_options = dataclasses.asdict(self.form_options)
-        self.form_options = FormOptions(**(old_options | kwargs))
+        self.form_options = FormOptions(**dict(old_options, **kwargs))
         return self
 
     def field(self, *names: str, **kwargs: str) -> RendererContext:
@@ -124,12 +124,12 @@ class RendererContext:
             old_options = dataclasses.asdict(
                 self.field_options.get(name, self.default_field_options)
             )
-            self.field_options[name] = FieldOptions(**(old_options | kwargs))
+            self.field_options[name] = FieldOptions(**dict(old_options, **kwargs))
         return self
 
     def default_field(self, **kwargs: str) -> RendererContext:
         self.default_field_options = FieldOptions(
-            **(dataclasses.asdict(self.default_field_options) | kwargs)
+            **dict(dataclasses.asdict(self.default_field_options), **kwargs)
         )
         return self
 

--- a/wtforms_bootstrap5/renderers.py
+++ b/wtforms_bootstrap5/renderers.py
@@ -69,7 +69,7 @@ def render_form(context: RendererContext, element: FormElement) -> Markup:
         content,
         enabled=form_options.form_enabled,
         class_name=form_options.form_class,
-        attrs=base_attrs | form_options.form_attrs,
+        attrs=dict(base_attrs, **form_options.form_attrs),
         tag="form",
     )
 


### PR DESCRIPTION
#2 was actually not complete yet, one other small change needed for 3.8. Shame about the newer syntax, it is a bit nicer.